### PR TITLE
Add sdl-generic-hmi.bb (generic_hmi)

### DIFF
--- a/recipes-automotive/sdl-generic-hmi/sdl-generic-hmi_git.bb
+++ b/recipes-automotive/sdl-generic-hmi/sdl-generic-hmi_git.bb
@@ -1,0 +1,34 @@
+SUMMARY = "HTML based reference HMI for SmartDeviceLink"
+DESCRIPTION = "SmartDeviceLink (SDL) is a standard set of protocols and \
+messages that connect applications on a smartphone to a vehicle head \
+unit."
+HOMEPAGE = "https://www.smartdevicelink.com"
+SECTION = "app"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=cf455e8d39d2ded1d85b1c5dea6ec3c5"
+
+SRC_URI = "git://github.com/smartdevicelink/generic_hmi.git;branch=develop"
+
+PV = "0.0.0+git${SRCPV}"
+SRCREV = "8d05d53d228d1dec82b78af824e33a0de5697e0c"
+
+S = "${WORKDIR}/git"
+
+PACKAGES = " \
+    ${PN} \
+"
+
+FILES_${PN}_append = " \
+    ${datadir}/smartdevicelink/generic_hmi/ \
+"
+
+do_install() {
+    install -d ${D}${datadir}/smartdevicelink/generic_hmi
+    install -m 0644 ${S}/index.html ${D}${datadir}/smartdevicelink/generic_hmi/
+    install -d ${D}${datadir}/smartdevicelink/generic_hmi/build
+    install -m 0644 ${S}/build/* ${D}${datadir}/smartdevicelink/generic_hmi/build
+    install -d ${D}${datadir}/smartdevicelink/generic_hmi/fonts
+    install -m 0644 ${S}/fonts/* ${D}${datadir}/smartdevicelink/generic_hmi/fonts
+}
+


### PR DESCRIPTION
This is a fixed version of  the PR #1 by @gunnarx according to the comments by @phongt. Unfortunately I didn't have the permissions to add my fix on top of @gunnarx PR so I've created a separate PR here for the fix. 

Is this PR acceptable @phongt ?

NOTE: The required files for the HMI are only index.html and
build/bundle.js.  Those are provided by the git repository and simply
installed by this recipe, but they seem to be originally created out of
some build process using node.js & webpack(?)  I want to note that this
bitbake recipe is NOT including any rebuild from source material since
the result files have been provided, and since I'm not sure how that is
intended to work for this repository. This approach serves our purposes
for now.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>
Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>