### PR TITLE
Fix build for distros not using pulseaudio/bluez

### DIFF
--- a/recipes-automotive/sdl-core/sdl-core/0001-Unbreak-build-when-BUILD_BT_SUPPORT-OFF.patch
+++ b/recipes-automotive/sdl-core/sdl-core/0001-Unbreak-build-when-BUILD_BT_SUPPORT-OFF.patch
@@ -1,0 +1,35 @@
+From b855147b17f00a7fcbe8d7a53970a24505737cda Mon Sep 17 00:00:00 2001
+From: Matt Hoosier <matt.hoosier@garmin.com>
+Date: Wed, 18 Apr 2018 11:48:30 -0500
+Subject: [PATCH] Unbreak build when BUILD_BT_SUPPORT=OFF
+
+Fixes a logic error in computing source-exclusion lists.
+---
+ src/components/transport_manager/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/components/transport_manager/CMakeLists.txt b/src/components/transport_manager/CMakeLists.txt
+index 8c7980a..ae80fe1 100644
+--- a/src/components/transport_manager/CMakeLists.txt
++++ b/src/components/transport_manager/CMakeLists.txt
+@@ -69,7 +69,7 @@ endif()
+ 
+ if(BUILD_USB_SUPPORT)
+   if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+-    set(EXCLUDE_PATHS
++    list(APPEND EXCLUDE_PATHS
+       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/qnx
+       ${COMPONENTS_DIR}/transport_manager/src/usb/qnx
+     )
+@@ -77,7 +77,7 @@ if(BUILD_USB_SUPPORT)
+       Libusb-1.0.16
+     )
+   elseif(CMAKE_SYSTEM_NAME STREQUAL "QNX")
+-    set(EXCLUDE_PATHS
++    list(APPEND EXCLUDE_PATHS
+       ${COMPONENTS_DIR}/transport_manager/include/transport_manager/usb/libusb
+       ${COMPONENTS_DIR}/transport_manager/src/usb/libusb
+     )
+-- 
+1.9.1
+


### PR DESCRIPTION
This changes makes all the Bluetooth and Pulseaudio features
(which are optional in the source code) conditional upon the
respective presence of the 'bluetooth' and 'pulseaudio'
DISTRO_FEATURES.

Also changed the the use of FOO_append's to standard concatenation
(FOO +=) so that bbappend files can rewrite these variables if
needed.